### PR TITLE
Add curation policy P001

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@ This repository is meant to be used as an archive for current and past versions 
 
 Please note that this project is released with a [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
+The UAT's [curation policies](./Documentation/curation_policies/curation_policies) will be used to assess and resolve change requests.
+
 Methods for providing contributions:
 
 Raise a GitHub Issue: https://github.com/astrothesaurus/UAT/issues

--- a/Documentation/curation_policies/README.md
+++ b/Documentation/curation_policies/README.md
@@ -1,0 +1,15 @@
+# Curation Policies
+
+*This directory contains the Unified Astronomy Thesaurus's curation policies. As indicated in their headers, a policy may be a "draft" for discussion, a "recommendation" by the Curation subcommittee of the WGUAT, or "approved" by the broader WGUAT. Please address feedback to <uat-curation@googlegroups.com>, or post a GitHub issue.*
+
+Any member of the Working Group on the Unified Astronomy Thesaurus (**WGUAT**) may author a policy with a status of Draft, for review by Curation. In some cases, Curation may designate another member(s) to lead revisions to a draft. Any member of the WGUAT may leave an in-line comment on any policy or policy draft.
+
+Here and throughout all policies and policy drafts, “**Curation**” refers to the members of the WGUAT Curation Subcommittee, which includes the UAT Curator or Acting Curator, and any external designees at the discretion of the subcommittee.
+
+Curation should aim to develop policy recommendations by consensus, with advanced notice of the topic by the Friday preceding the monthly WGUAT meeting. If consensus cannot be reached, policy recommendations will be moved forward by majority vote of the WGUAT Curation Subcommittee members. If subcommittee members were missing for the vote, their votes should be obtained asynchronously following the meeting.  The UAT Curator or Acting Curator has a vote.
+
+On receiving a policy recommendation by Curation, the broader WGUAT must vote on whether to approve the recommendation, in a vote to be held at a regular monthly WGUAT meeting. Advance notice and the text of the policy recommendation must be provided at least one week prior to the vote. To approve the recommendation, more WGUAT members must vote to approve than to reject. The Curator or Acting Curator has a vote.
+
+During the meeting in which a vote is to take place, *at least* 30 minutes must be reserved for discussing the matter, unless waived by consensus, out of which 15 minutes are available to the Curation Subcommittee chair and/or their designees to present the recommendation. This vote is to be treated as an approve or “return to committee” vote - that is, the full WUGAT should not aim to word-smith the text at this discussion, but rather raise any concerns and if significant changes are required, to pass it back to the Curation sub-committee to revise and bring back to the next monthly WUGAT meeting.
+
+At the discretion of the WGUAT chair, Curation may act in alignment with an internally developed policy recommendation while a vote by the WGUAT is pending.

--- a/Documentation/curation_policies/p001.md
+++ b/Documentation/curation_policies/p001.md
@@ -1,0 +1,73 @@
+# Review Process for Changes in the UAT Vocabulary
+
+*Policy ID:* P001
+
+*Status:* Approved by the WGUAT on 2025 Nov 18
+
+## Section A. Overview
+
+The UAT is vast in scope, strives to meet a variety of downstream requirements, will never be perfect, and prioritizes being a dynamic, quickly evolving vocabulary with relatively lightweight requirements for the ingestion of updates suggested by the community while maintaining high standards of scholarship.
+
+To that end, our review process for ingesting changes into the UAT vocabulary follows a “flag for escalated review” model, whereby many changes can get ingested with approval by a single member of Curation, but any change must wait at least one month to be approved (the length of time between WGUAT meetings), during which time any member of Curation can flag a change as requiring escalated review. The reasons for moving to escalated review may be as simple as “I have input but I don’t have time to chime in right now”; no justification is required.
+
+## Section B. Assessment Criteria
+
+Curation, whether acting through quick review by a single member or through escalated review by a larger group, must determine that every change meets the assessment criteria below.
+
+The most critical criteria are that the change…
+
+- …is not unduly **ambiguous**, unless it is a parent term designed to be intentionally ambiguous.
+  - Failing to meet this criterion often leads to *irreversible* problems.
+  - For example, a planetary magnetosphere concept “Lobes” could be confused with radio lobes in AGN/YSO/stellar jets, and must be disambiguated. Upon ingesting “Lobes,” it would rapidly be used by paper authors to tag both planetary magnetosphere lobes and astrophysical jet lobes, and thus cease in practice to be a planetary magnetospheres concept.
+  - In this particular case, a parent concept unifying "Jet lobes" and "Lobes (planetary magnetospheres)" probably wouldn't be useful, so options to solve the issue post-ingestion would be extremely limited.
+  - Put another way: when designing concepts, it is equally important to think about what a concept is not, as it is to think about what a concept is.
+
+- …is **reviewed** by at least one member of Curation who did not submit the proposed change.
+
+- …was either suggested or reviewed by at least one **subject matter expert** (SME) in the applicable subfield of astronomy, unless the change does not require subject matter expertise in the judgement of the member(s) reviewing the change. WGUAT members, including members of Curation, are eligible to be SMEs if the change lies within their particular subfield.
+  - For changes requiring subject matter expertise, it is encouraged to obtain review by at least one independent SME who did not author the proposed change. However, this is not a requirement unless Curation determines during Escalated Review that additional SME(s) are necessary.
+  - Broadly speaking, Curation is not primarily responsible for determining whether a change is scientifically accurate, unless a member of Curation chooses to act as an SME; rather, our responsibility is to ensure that a change involved at least one SME. However, any member of Curation may use their own scientific expertise to object to a change or flag a change for escalated review.
+
+The remainder of the assessment criteria are also important, but are generally fixable after ingestion if they are not strictly adhered to. Some laxness on the following criteria may be permissible in the spirit of not allowing perfectionism to make UAT ingest too sluggish. These less critical criteria include ensuring that the change…
+
+- …does not exacerbate the UAT’s **transitivity** issues. Each created or altered concept must be *always a type of its parents or always a component of its parents*, and/or data and papers tagged with the concept must always also contain its parents. “Always” means “in all astronomical contexts,” including solar system science, planetary science, and laboratory astrophysics.
+  - This criterion depends on meeting the ambiguity criterion above; concepts with intentional scope are a pre-condition of powering transitive query expansion.
+- …entails **plural** prefLabels and altLabels except in special circumstances (e.g., Earth, Heliopause). If this criterion is not met, it does not need to be addressed by the reviewer in detail, but do raise the issue to the attention of the Curator or whoever else will be ingesting these concepts in PoolParty.
+
+- …is **in-scope** for the UAT, in the case of creating new concepts.
+
+- …is **conformant** with other Curation policies approved by the WGUAT.
+
+- …is **communicated** clearly in a Github issue or pull request, including a correct, human-readable list of changes and an explanation or discussion log of their motivation, including the names of any SMEs who contributed.
+
+- …gets flagged for escalated review if it is likely, in the judgement of the reviewer, to be **controversial** within Curation.
+
+## Section C. Review workflow for a proposed change 
+
+**Step 1:** A list of proposed changes will be compiled and presented to the Curation Subcommittee during each WGUAT meeting, by the Curation Subcommittee chair or their designee, with the assistance of institutional partners and the New Content Subcommittee chair where applicable. This list will be preserved in the Curation Subcommittee’s meeting minutes.
+
+**Step 2:** Members of Curation will then have the next month, until the next meeting of the WGUAT, to flag certain changes for escalated review.
+They may do so for any reason, including but not limited to the visibility of the change, the scale or irreversibility of the change, the need for more time to fix problems with the change, or objections to the change.
+Additionally, if multiple members of Curation have input on a change during this month and they are unable to reach an agreement with each other, the change must be flagged for escalated review.
+
+**Step 3:** After a month, on the day of the WGUAT meeting:
+
+- …a change that was not flagged for escalated review may now be approved or rejected by any individual member of Curation who did not submit the change. That individual must ensure that the Assessment Criteria (Section B above) are met, and they retain the option to flag the change for escalated review even after the initial month has passed. If the change requires revision, the revision may or may not go back to Step 1, at the discretion of the individual reviewer.
+- …a change that was flagged proceeds to Escalated Review.
+
+## Section D. Escalated Review
+
+A change flagged for escalated review will be added to the WGUAT Curation Subcommittee's meeting agenda at their earliest availability. Curation will discuss the change, and may decide by consensus to…
+
+- …designate (an) individual(s) to work on fixing identified issues with the change.
+- …consult with one or more additional SMEs for further scientific review.
+- …postpone the change until sufficient labor time is available to work through any issues.
+- …reject the change.
+- …approve the change, if and only if it meets the Assessment Criteria (Section B).
+
+The above list of potential actions is not exhaustive.
+
+In the event that consensus is not reached during this discussion, Curation may either…
+
+- …by default, postpone the change by one month, during which further discussion may be had, work may be done, or positions may be shared with the Curation chair and UAT Curator. At the end of the month, the Curation chair and the Curator may choose to make a decision together or reintroduce the matter at a future meeting, at their discretion.
+- …by majority vote, prevent the change for now. The matter may be reintroduced no earlier than six months later, except by consensus of the Curation subcommittee.


### PR DESCRIPTION
This PR adds curation policy P001 (Review Process for Changes in the UAT Vocabulary) exactly as approved by the WGUAT on Nov 18 2025. It also adds the policy from the WGUAT for how curation policies get approved.